### PR TITLE
[Add] 商品詳細ページ追加

### DIFF
--- a/app/controllers/customers/items_controller.rb
+++ b/app/controllers/customers/items_controller.rb
@@ -5,5 +5,7 @@ class Customers::ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
+    @cart_item = CartItem.new
   end
 end

--- a/app/views/customers/items/index.html.erb
+++ b/app/views/customers/items/index.html.erb
@@ -7,8 +7,10 @@
     <div class="d-flex flex-wrap mb-2">
       <% @items.each do |item| %>
        <div class="col-xs-3 pr-5 mb-4">
-         <%= attachment_image_tag item, :image, :fill, 200, 150, fallback: "no_image.jpg" %><br>
-         <%= item.name %><br>
+         <%= link_to item_path(item.id),style: "color: black;" do %>
+           <%= attachment_image_tag item, :image, :fill, 200, 150, fallback: "no_image.jpg" %><br>
+           <%= item.name %><br>
+         <% end %>
          <%= item.price.to_s(:delimited, delimiter: ',') %>円
        </div>
       <% end %>

--- a/app/views/customers/items/show.html.erb
+++ b/app/views/customers/items/show.html.erb
@@ -1,2 +1,27 @@
-<h1>Customers::Items#show</h1>
-<p>Find me in app/views/customers/items/show.html.erb</p>
+<div class="container mt-5 mb-5">
+ <div class="row">
+   <div class="d-flex">
+     <div class="col-mb-5 mx-5">
+       <%= attachment_image_tag @item, :image, :fill, 300, 300, fallback: "no_image.jpg", size:'380x300' %>
+     </div>
+     <div class="col-mb-5 ml-5 mt-3 w-25">
+      <h3 class="font-weight-bold"><%= @item.name %></h3>
+      <p><%= @item.introduction %></p>
+       <div class="mt-5">
+        <strong class="h3"><%= @item.price.to_s(:delimited, delimiter: ',') %>円</strong>
+        <span class="text-muted">(税込)</span>
+       </div>
+       <div class="d-flex mt-4">
+        <div class="col-xs-5 mr-4">
+         <%= form_with model:@cart_item, url: cart_items_path(item_id: @item), local:true do |f| %>
+         <%= f.select :quantity, [['1個', 1], ['2個', 2], ['3個', 3], ['4個', 4], ['5個', 5], ['6個', 6], ['7個', 7], ['8個', 8], ['9個', 9]], {:prompt => "個数選択"}, class: "btn btn-light dropdown-toggle" %>
+        </div>
+        <div class="col-xs-5 ml-4">
+         <%= f.submit 'カートに入れる', class: 'btn btn-primary btn-success' %>
+        </div>
+         <% end %>
+      </div>
+     </div>
+   </div>
+ </div>
+</div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,12 +53,12 @@ end
      )
  end
 
- # 10.times do |n|
- #  Item.create!(
- #      name: "チョコケーキ#{n + 1}",
- #      genre_id: n + 1,
- #      introduction: "チョコケーキ最高チョコケーキ最高チョコケーキ最高チョコケーキ最高チョコケーキ最高チョコケーキ最高",
- #      price: 10 + n * 100,
- #      image: open("./app/assets/images/cake-2001781_1280.jpg")
- #    )
- # end
+ 3.times do |n|
+  Item.create!(
+      name: "チョコケーキ#{n + 1}",
+      genre_id: n + 1,
+      introduction: "チョコケーキ最高チョコケーキ最高チョコケーキ最高チョコケーキ最高チョコケーキ最高チョコケーキ最高",
+      price: 1000 + n * 100,
+      image: open("./app/assets/images/cake-2001781_1280.jpg")
+    )
+ end


### PR DESCRIPTION
商品詳細画面追加
topページから、商品詳細ページまで遷移可能
カートへ追加機能については、カートアイテムコントローラーの作成がまだのため、検証していません。