### PR TITLE
[Add] 管理者側のtop兼注文履歴一覧の作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,9 +43,16 @@
 .all_item {
    text-align: right;
 }
+
+.wrapper{
+    min-height: 100vh;
+    position: relative;/*←相対位置*/
+    padding-bottom: 120px;/*←footerの高さ*/
+    box-sizing: border-box;/*←全て含めてmin-height:100vhに*/
+}
+
 footer{
    width: 100%;
    position: absolute;
    bottom: 0;
 }
-

--- a/app/controllers/admins/homes_controller.rb
+++ b/app/controllers/admins/homes_controller.rb
@@ -1,4 +1,11 @@
 class Admins::HomesController < ApplicationController
   def top
+    path = Rails.application.routes.recognize_path(request.referer)
+    if path[:controller] == "admins/customers" && path[:action] == "show"
+     @customer = Customer.find(params[:id])   
+     @orders = @customer.order.page(params[:page]).per(10)
+    else
+     @orders = Order.page(params[:page]).per(10)
+    end
   end
 end

--- a/app/views/admins/homes/top.html.erb
+++ b/app/views/admins/homes/top.html.erb
@@ -1,2 +1,34 @@
-<h1>Admins::Homes#top</h1>
-<p>Find me in app/views/admins/homes/top.html.erb</p>
+<div class="container mt-4 mb-4">
+  <div class="row mx-auto">
+    <div class="col-xs-10">
+      <section class="headline mb-3">
+       <h3>注文履歴一覧</h3>
+      </section>
+      <div class="order-table">
+        <table class="table">
+          <thead>
+            <tr class="table-secondary">
+              <th>購入日時</th>
+              <th>購入者</th>
+              <th>注文個数</th>
+              <th>注文ステータス</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @orders.each do |order| %>
+             <tr>
+               <td><%= link_to order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admins_order_path(order), class: "text-dark" %></td>
+               <td><%= order.customer.last_name + order.customer.first_name %></td>
+               <td><%= order.order_details.sum(:quantity) %></td>
+               <td><%= order.order_details %></td>
+             </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+   <div class="mx-auto"><%= paginate @orders %></div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,130 +9,132 @@
   </head>
 
   <body>
-    <header>
-      <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="/">
-        <i class="fas fa-utensils fa-fw"></i>ながのCAKE</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-          <ul class="navbar-nav ml-auto">
-            <!-- 会員側でログイン時 -->
-            <% if customer_signed_in? %>
-              <li class="youkoso">
-                ようこそ、<%= current_customer.last_name %>さん！
-              </li>
-              <div class="navbar-nav">
-                <li class="nav-item">
-                  <%= link_to customers_my_page_path do %>
-                    <i class="fas fa-user"></i>
-                    マイページ
-                  <% end %>
+  <div class="wrapper">
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+          <a class="navbar-brand" href="/">
+          <i class="fas fa-utensils fa-fw"></i>ながのCAKE</a>
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+            <ul class="navbar-nav ml-auto">
+              <!-- 会員側でログイン時 -->
+              <% if customer_signed_in? %>
+                <li class="youkoso">
+                  ようこそ、<%= current_customer.last_name %>さん！
                 </li>
-                <li class="nav-item">
-                  <%= link_to items_path do %>
-                    <i class="fas fa-cookie-bite fa-fw"></i>
-                    商品一覧
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to cart_items_path do %>
-                    <i class="fas fa-shopping-cart fa-fw"></i>
-                    カート
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to destroy_customer_session_path, method: :delete do %>
-                    <i class="fas fa-sign-out-alt fa-fw"></i>
-                    ログアウト
-                  <% end %>
-                </li>
-            <!-- 管理者側でログイン時-->
-            <% elsif admin_signed_in? %>
-                <li class="nav-item">
-                  <%= link_to admins_items_path do %>
-                    <i class="fas fa-cookie-bite fa-fw"></i>
-                    商品一覧
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to admins_customers_path do %>
-                    <i class="fas fa-users fa-fw"></i>
-                    会員一覧
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to admins_root_path do %>
-                    <i class="fas fa-history fa-fw"></i>
-                    注文履歴一覧
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to admins_genres_path do %>
-                    <i class="far fa-user fa-fw"></i>
-                    ジャンル一覧
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to destroy_admin_session_path, method: :delete do %>
-                    <i class="fas fa-sign-in-alt fa-fw"></i>
-                    ログアウト
-                  <% end %>
-                </li>
-            <!-- ログインしてない時 -->
-            <% else %>
-              <div class="navbar-nav">
-                <li class="nav-item">
-                  <%= link_to about_path do %>
-                    <i class="fab fa-speakap fa-fw"></i>
-                    About
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to items_path do %>
-                    <i class="fas fa-cookie-bite fa-fw"></i>
-                    商品一覧
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to new_customer_registration_path do %>
-                    <i class="far fa-user fa-fw"></i>
-                    新規登録
-                  <% end %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to new_customer_session_path do %>
-                    <i class="fas fa-sign-in-alt fa-fw"></i>
-                    ログイン
-                  <% end %>
-                </li>
-              </div>
-            <% end %>
-          </ul>
+                <div class="navbar-nav">
+                  <li class="nav-item">
+                    <%= link_to customers_my_page_path do %>
+                      <i class="fas fa-user"></i>
+                      マイページ
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to items_path do %>
+                      <i class="fas fa-cookie-bite fa-fw"></i>
+                      商品一覧
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to cart_items_path do %>
+                      <i class="fas fa-shopping-cart fa-fw"></i>
+                      カート
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to destroy_customer_session_path, method: :delete do %>
+                      <i class="fas fa-sign-out-alt fa-fw"></i>
+                      ログアウト
+                    <% end %>
+                  </li>
+              <!-- 管理者側でログイン時-->
+              <% elsif admin_signed_in? %>
+                  <li class="nav-item">
+                    <%= link_to admins_items_path do %>
+                      <i class="fas fa-cookie-bite fa-fw"></i>
+                      商品一覧
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to admins_customers_path do %>
+                      <i class="fas fa-users fa-fw"></i>
+                      会員一覧
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to admins_root_path do %>
+                      <i class="fas fa-history fa-fw"></i>
+                      注文履歴一覧
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to admins_genres_path do %>
+                      <i class="far fa-user fa-fw"></i>
+                      ジャンル一覧
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to destroy_admin_session_path, method: :delete do %>
+                      <i class="fas fa-sign-in-alt fa-fw"></i>
+                      ログアウト
+                    <% end %>
+                  </li>
+              <!-- ログインしてない時 -->
+              <% else %>
+                <div class="navbar-nav">
+                  <li class="nav-item">
+                    <%= link_to about_path do %>
+                      <i class="fab fa-speakap fa-fw"></i>
+                      About
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to items_path do %>
+                      <i class="fas fa-cookie-bite fa-fw"></i>
+                      商品一覧
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to new_customer_registration_path do %>
+                      <i class="far fa-user fa-fw"></i>
+                      新規登録
+                    <% end %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to new_customer_session_path do %>
+                      <i class="fas fa-sign-in-alt fa-fw"></i>
+                      ログイン
+                    <% end %>
+                  </li>
+                </div>
+              <% end %>
+            </ul>
+          </div>
+        </nav>
+      </header>
+      <!--フラッシュメッセージ-->
+      <% if flash[:notice] %>
+        <div class="alert alert-primary" role="alert"><strong><%= notice %></strong></div>
+      <% end %>
+
+      <% if flash[:alert] %>
+        <div class="alert alert-danger" role="alert"><strong><%= alert %></strong></div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div class="alert alert-danger" role="alert"><strong><%= flash[:error] %></strong></div>
+      <% end %>
+
+      <main>
+        <%= yield %>
+      </main>
+      <footer class="bg-dark text-white pt-5 pb-4">
+        <div>
+          <p class="text-center">ながのCAKE製作委員会</p>
         </div>
-      </nav>
-    </header>
-    <!--フラッシュメッセージ-->
-    <% if flash[:notice] %>
-      <div class="alert alert-primary" role="alert"><strong><%= notice %></strong></div>
-    <% end %>
-
-    <% if flash[:alert] %>
-      <div class="alert alert-danger" role="alert"><strong><%= alert %></strong></div>
-    <% end %>
-
-    <% if flash[:error] %>
-      <div class="alert alert-danger" role="alert"><strong><%= flash[:error] %></strong></div>
-    <% end %>
-
-    <main>
-      <%= yield %>
-    </main>
-    <footer class="bg-dark text-white pt-5 pb-4">
-      <div>
-        <p class="text-center">ながのCAKE製作委員会</p>
-      </div>
-    </footer>
+      </footer>
+  </div>
   </body>
 </html>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,9 +34,9 @@ end
  end
 
 
-  5.times do |n|
+ 12.times do |n|
   Order.create!(
-      customer_id: n + 1,
+      customer_id: 1,
       send_name: "太郎#{n + 1}",
       postal_code: "1234567",
       address: "広島県八千代1−1−1",


### PR DESCRIPTION
#管理者側の注文履歴一覧の作成
・admins/homes/topに注文履歴一覧作を作成
・homesコントローラー作成
・ヘッダーからの遷移は確認したが、会員詳細からの遷移は確認していません。
(補足)履歴を10件表示させるとヘッダーと被ったためlapplication.htmlとcssの記述を追記しています。