### PR TITLE
[Fix]新着商品のリンク作成

### DIFF
--- a/app/views/customers/homes/top.html.erb
+++ b/app/views/customers/homes/top.html.erb
@@ -20,11 +20,13 @@
  <div class="container">
   <div class="row">
     <% @items.last(4).each do |item| %>
-     <div class="col-md-3" style="padding-right: 0px; padding-left: 0px; margin: 10px 0;">
-       <%= attachment_image_tag item, :image, :fill, 200, 150, fallback: "no_image.jpg" %><br>
-       <%= item.name %><br>
-       <%= item.price.to_s(:delimited, delimiter: ',') %>円
-     </div>
+      <div class="col-md-3" style="padding-right: 0px; padding-left: 0px; margin: 10px 0;">
+        <%= link_to item_path(item), 'data-turbolinks': false do %>
+          <%= attachment_image_tag item, :image, :fill, 200, 150, fallback: "no_image.jpg" %><br>
+          <%= item.name %><br>
+          <%= item.price.to_s(:delimited, delimiter: ',') %>円
+        <% end %>
+      </div>
     <% end %>
   </div>
   <div class="all_item">


### PR DESCRIPTION
-top画面の新着商品から商品詳細に画面の遷移できるようにしました
-画面遷移後にturbolinksを無効化し、カートボタンが動作するように設定しました